### PR TITLE
Install charmcraft in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,9 @@ jobs:
         set -eux
         sudo snap install charm --classic
         sudo snap install juju-helpers --classic --channel edge
+        sudo apt update
+        sudo apt install python3-pip
+        sudo pip3 install charmcraft
 
     - name: Publish bundle
       env:


### PR DESCRIPTION
With the switch to the operator framework, the publishing job needs to have charmcraft installed.