### PR TITLE
Split up service-mesh interface

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -85,6 +85,9 @@ jobs:
     - name: Ensure bookinfo came up
       run: curl -fv http://10.64.140.43/productpage
 
+    - run: juju status
+      if: failure()
+
     - name: Get pod statuses
       run: kubectl get all -A
       if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.charm
 *__pycache__
 *.tox
+build/

--- a/charms/istio-ingressgateway/metadata.yaml
+++ b/charms/istio-ingressgateway/metadata.yaml
@@ -39,4 +39,6 @@ provides:
 requires:
   istio-pilot:
     interface: k8s-service
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    versions: [v1]
 min-juju-version: 2.8-beta1

--- a/charms/istio-ingressgateway/requirements.txt
+++ b/charms/istio-ingressgateway/requirements.txt
@@ -1,4 +1,4 @@
-ops==1.1.0
-git+https://github.com/charmed-kubernetes/interface-k8s-service
-oci-image==1.0.0
 kubernetes
+oci-image==1.0.0
+ops==1.1.0
+serialized-data-interface==0.2.0

--- a/charms/istio-ingressgateway/test/unit/test_charm.py
+++ b/charms/istio-ingressgateway/test/unit/test_charm.py
@@ -40,7 +40,7 @@ def test_main_no_relation(harness):
     # confirm that we can serialize the pod spec
     yaml.safe_dump(pod_spec)
 
-    assert isinstance(harness.charm.model.unit.status, BlockedStatus)
+    assert isinstance(harness.charm.model.unit.status, WaitingStatus)
 
 
 @patch("charm.Operator.check_ca_root_cert")
@@ -59,15 +59,17 @@ def test_main_with_relation(mock_ca_check, harness):
         },
     )
     rel_id = harness.add_relation("istio-pilot", "app")
-    harness.begin_with_initial_hooks()
-    assert isinstance(harness.charm.model.unit.status, WaitingStatus)
     harness.add_relation_unit(rel_id, "app/0")
     harness.update_relation_data(
         rel_id,
         "app",
-        {"service-name": "istio-pilot", "service-port": "15010"},
+        {
+            "_supported_versions": "- v1",
+            "data": yaml.dump({"service-name": "istio-pilot", "service-port": "15010"}),
+        },
     )
 
+    harness.begin_with_initial_hooks()
     pod_spec = harness.get_pod_spec()
     yaml.safe_dump(pod_spec)
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -33,6 +33,14 @@ resources:
 provides:
   istio-pilot:
     interface: k8s-service
-  service-mesh:
-    interface: service-mesh-ops
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    versions: [v1]
+  ingress:
+    interface: ingress
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress.yaml
+    versions: [v1]
+  ingress-auth:
+    interface: ingress-auth
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress-auth.yaml
+    versions: [v1]
 min-juju-version: 2.8-beta1

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -2,4 +2,4 @@ ops==1.1.0
 git+https://github.com/charmed-kubernetes/interface-k8s-service
 oci-image==1.0.0
 jinja2==2.11.3
-git+https://github.com/canonical/interface-service-mesh
+serialized-data-interface==0.2.0

--- a/charms/istio-pilot/test/unit/test_charm.py
+++ b/charms/istio-pilot/test/unit/test_charm.py
@@ -52,22 +52,20 @@ def test_main_service_mesh(harness):
             "password": "",
         },
     )
-    rel_id = harness.add_relation("service-mesh", "app")
-    harness.begin_with_initial_hooks()
+    rel_id = harness.add_relation("ingress", "app")
     harness.add_relation_unit(rel_id, "app/0")
     data = {
         "prefix": "/app",
         "rewrite": "/app",
         "service": "my-service",
         "port": 4242,
-        "ingress": False,
-        "auth": {},
     }
     harness.update_relation_data(
         rel_id,
         "app",
-        {"data": yaml.dump(data)},
+        {"_supported_versions": "- v1", "data": yaml.dump(data)},
     )
+    harness.begin_with_initial_hooks()
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)
     pod_spec = harness.get_pod_spec()
     for virtual_service in pod_spec[1]["kubernetesResources"]["customResources"][

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,14 @@ deps =
 
 [testenv:lint]
 commands =
-    flake8 {toxinidir}/charms
-    black --check {toxinidir}
+    flake8 \
+        {toxinidir}/charms/istio-pilot/src \
+        {toxinidir}/charms/istio-pilot/test \
+        {toxinidir}/charms/istio-ingressgateway/src \
+        {toxinidir}/charms/istio-ingressgateway/test
+
+    black --check \
+        {toxinidir}/charms/istio-pilot/src \
+        {toxinidir}/charms/istio-pilot/test \
+        {toxinidir}/charms/istio-ingressgateway/src \
+        {toxinidir}/charms/istio-ingressgateway/test


### PR DESCRIPTION
Splits up service-mesh interface into ingress and ingress-auth interfaces, and uses the `schema` property for them. Punts on defining a full service-mesh interface until actually necessary to create.