### PR TITLE
Set ActiveStatus by default after version checking

### DIFF
--- a/charms/istio-ingressgateway/src/charm.py
+++ b/charms/istio-ingressgateway/src/charm.py
@@ -29,6 +29,8 @@ class Operator(CharmBase):
         except NoCompatibleVersions as err:
             self.model.unit.status = BlockedStatus(str(err))
             return
+        else:
+            self.model.unit.status = ActiveStatus()
 
         self.log = logging.getLogger(__name__)
         self.image = OCIImageResource(self, "oci-image")

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -30,6 +30,8 @@ class Operator(CharmBase):
         except NoCompatibleVersions as err:
             self.model.unit.status = BlockedStatus(str(err))
             return
+        else:
+            self.model.unit.status = ActiveStatus()
 
         self.log = logging.getLogger(__name__)
         self.image = OCIImageResource(self, "oci-image")


### PR DESCRIPTION
Prevents a charm from getting stuck in WaitingStatus