### PR TITLE
Rejigger how tox works

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,45 +5,20 @@ on:
   - pull_request
 
 jobs:
-  lint:
-    name: Lint Code
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out repo
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-    - name: Install tox
-      run: |
-        sudo apt-get install tox
-
-    - name: Linting
-      run: |
-        tox
-
   unit-test:
-    name: Run Unit Tests
+    name: Unit Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        charm: [pilot, ingressgateway]
 
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-    - name: Install tox
-      run: |
-        sudo apt-get install tox
+    - uses: actions/checkout@v2
+    - run: sudo apt install tox
+    - run: tox -e ${{ matrix.charm }}
 
-    - name: Unit Tests and Linting
-      run: |
-        cd charms/istio-pilot
-        tox -e unit
-        cd ../istio-ingressgateway
-        tox -e unit
-
-  functional-test:
-    name: Deploy to microk8s
+  integration-test:
+    name: Integration Test
     runs-on: ubuntu-latest
 
     steps:

--- a/charms/istio-ingressgateway/test-requirements.txt
+++ b/charms/istio-ingressgateway/test-requirements.txt
@@ -1,1 +1,3 @@
 pytest
+black
+flake8

--- a/charms/istio-ingressgateway/tox.ini
+++ b/charms/istio-ingressgateway/tox.ini
@@ -14,3 +14,8 @@ deps =
 [testenv:unit]
 commands = 
 	pytest test/unit
+
+[testenv:lint]
+commands =
+    flake8 {toxinidir}/src {toxinidir}/test
+    black --check {toxinidir}/src {toxinidir}/test

--- a/charms/istio-pilot/test-requirements.txt
+++ b/charms/istio-pilot/test-requirements.txt
@@ -1,1 +1,3 @@
 pytest
+black
+flake8

--- a/charms/istio-pilot/tox.ini
+++ b/charms/istio-pilot/tox.ini
@@ -14,3 +14,8 @@ deps =
 [testenv:unit]
 commands = 
 	pytest test/unit
+
+[testenv:lint]
+commands =
+    flake8 {toxinidir}/src {toxinidir}/test
+    black --check {toxinidir}/src {toxinidir}/test

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,9 @@ max-line-length = 150
 
 [tox]
 skipsdist = True
+envlist = {ingressgateway,pilot}
 
 [testenv]
-setenv =
-	PYTHONPATH={toxinidir}/src:{toxinidir}/lib
-deps =
-	-r{toxinidir}/lint-requirements.txt
-
-[testenv:lint]
-commands =
-    flake8 \
-        {toxinidir}/charms/istio-pilot/src \
-        {toxinidir}/charms/istio-pilot/test \
-        {toxinidir}/charms/istio-ingressgateway/src \
-        {toxinidir}/charms/istio-ingressgateway/test
-
-    black --check \
-        {toxinidir}/charms/istio-pilot/src \
-        {toxinidir}/charms/istio-pilot/test \
-        {toxinidir}/charms/istio-ingressgateway/src \
-        {toxinidir}/charms/istio-ingressgateway/test
+whitelist_externals = tox
+changedir = charms/istio-{envname}
+commands = tox


### PR DESCRIPTION
Running `tox` from the top-level now runs tox tests in each charm's directory, instead of a user having to cd to each subdir and run them individually.